### PR TITLE
유저 아이디, 닉네임 중복체크 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### yml ###
+*.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "2024_BEOTKKOTTHON_TEAM_19_BE_YML"]
+	path = 2024_BEOTKKOTTHON_TEAM_19_BE_YML
+	url = https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE_YML.git

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,28 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+task copyPrivate(type: Copy) {
+	copy {
+		from './2024_BEOTKKOTTHON_TEAM_19_BE_YML/private' //위 사진과 같은 폴더 명
+		include "*.yml" //위 폴더안에 있는 yml파일 명
+		into 'src/main/resources' //복사할 위치
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetails.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetails.java
@@ -31,7 +31,7 @@ public class PrincipalUserDetails implements UserDetails{
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return user.getNickname();
     }
 
     @Override

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetails.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetails.java
@@ -1,0 +1,57 @@
+package com.example.feelsun.config.auth;
+
+import com.example.shipgofunding.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class PrincipalUserDetails implements UserDetails{
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(new SimpleGrantedAuthority(user.getRole().toString()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetails.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetails.java
@@ -1,6 +1,6 @@
 package com.example.feelsun.config.auth;
 
-import com.example.shipgofunding.user.domain.User;
+import com.example.feelsun.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
@@ -19,14 +19,13 @@ public class PrincipalUserDetailsService implements UserDetailsService {
     private final UserJpaRepository userJpaRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Optional<User> optionalUser = userJpaRepository.findByEmail(email);
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Optional<User> optionalUser = userJpaRepository.findById(Long.parseLong(id));
 
         if (optionalUser.isEmpty()) {
             return null;
         }
         User user = optionalUser.get();
-        log.info("user : " + user);
         return new PrincipalUserDetails(user);
 
     }

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.example.feelsun.config.auth;
 
-import com.example.shipgofunding.user.domain.User;
-import com.example.shipgofunding.user.repository.UserRepository;
+import com.example.feelsun.domain.User;
+import com.example.feelsun.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -14,11 +14,11 @@ import java.util.Optional;
 @Service
 public class PrincipalUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
+    private final UserJpaRepository userJpaRepository;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Optional<User> optionalUser = userRepository.findByEmail(email);
+        Optional<User> optionalUser = userJpaRepository.findByEmail(email);
 
         if (optionalUser.isEmpty()) {
             return null;

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
@@ -3,6 +3,7 @@ package com.example.feelsun.config.auth;
 import com.example.feelsun.domain.User;
 import com.example.feelsun.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 
 @RequiredArgsConstructor
+@Slf4j
 @Service
 public class PrincipalUserDetailsService implements UserDetailsService {
 
@@ -24,6 +26,7 @@ public class PrincipalUserDetailsService implements UserDetailsService {
             return null;
         }
         User user = optionalUser.get();
+        log.info("user : " + user);
         return new PrincipalUserDetails(user);
 
     }

--- a/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
+++ b/src/main/java/com/example/feelsun/config/auth/PrincipalUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.example.feelsun.config.auth;
+
+import com.example.shipgofunding.user.domain.User;
+import com.example.shipgofunding.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class PrincipalUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+
+        if (optionalUser.isEmpty()) {
+            return null;
+        }
+        User user = optionalUser.get();
+        return new PrincipalUserDetails(user);
+
+    }
+
+}

--- a/src/main/java/com/example/feelsun/config/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/feelsun/config/errors/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.example.feelsun.config.errors;
+
+import com.example.feelsun.config.errors.exception.*;
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(Exception400.class)
+    public ResponseEntity<?> badRequest(Exception400 exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.body());
+    }
+
+    @ExceptionHandler(Exception401.class)
+    public ResponseEntity<?> unAuthorized(Exception401 exception) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exception.body());
+    }
+
+    @ExceptionHandler(Exception403.class)
+    public ResponseEntity<?> forbidden(Exception403 exception) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exception.body());
+    }
+
+    @ExceptionHandler(Exception404.class)
+    public ResponseEntity<?> notFound(Exception404 exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.body());
+    }
+
+    @ExceptionHandler(Exception500.class)
+    public ResponseEntity<?> serverError(Exception500 exception) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exception.body());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> unknownError(Exception exception) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponseBuilder.error(exception.getMessage()));
+    }
+}

--- a/src/main/java/com/example/feelsun/config/errors/GlobalValidationHandler.java
+++ b/src/main/java/com/example/feelsun/config/errors/GlobalValidationHandler.java
@@ -1,0 +1,45 @@
+package com.example.feelsun.config.errors;
+
+import com.example.feelsun.config.errors.exception.Exception400;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Aspect
+@Component
+public class GlobalValidationHandler {
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
+    public void postMapping() {}
+
+    @Before("postMapping()")
+    public void validationAdvice(JoinPoint joinPoint) {
+        Map<String, String> errorList = new HashMap<>();
+
+        Object[] args = joinPoint.getArgs(); // join point parameter
+
+        for (Object arg : args) {
+            if (arg instanceof Errors) {
+                Errors errors = (Errors) arg;
+
+                if (errors.hasErrors()) {
+                    List<FieldError> fieldErrors = errors.getFieldErrors();
+                    for (FieldError fieldError : fieldErrors) {
+                        errorList.put(fieldError.getField(), fieldError.getDefaultMessage());
+                    }
+                }
+            }
+        }
+
+        if (!errorList.isEmpty()) {
+            throw new Exception400(errorList, null);
+        }
+    }
+}

--- a/src/main/java/com/example/feelsun/config/errors/exception/Exception400.java
+++ b/src/main/java/com/example/feelsun/config/errors/exception/Exception400.java
@@ -1,0 +1,20 @@
+package com.example.feelsun.config.errors.exception;
+
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class Exception400 extends RuntimeException {
+    Map<String, String> errors;
+
+    public Exception400(Map<String, String> errors, String message) {
+        super(message);
+        this.errors = (errors != null) ? errors : null;
+    }
+
+    public ApiResponseBuilder.ApiResponse<?> body(){
+        return ApiResponseBuilder.fail(errors, getMessage());
+    }
+}

--- a/src/main/java/com/example/feelsun/config/errors/exception/Exception401.java
+++ b/src/main/java/com/example/feelsun/config/errors/exception/Exception401.java
@@ -1,0 +1,15 @@
+package com.example.feelsun.config.errors.exception;
+
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import lombok.Getter;
+
+@Getter
+public class Exception401 extends RuntimeException {
+    public Exception401(String message) {
+        super(message);
+    }
+
+    public ApiResponseBuilder.ApiResponse<?> body(){
+        return ApiResponseBuilder.error(getMessage());
+    }
+}

--- a/src/main/java/com/example/feelsun/config/errors/exception/Exception403.java
+++ b/src/main/java/com/example/feelsun/config/errors/exception/Exception403.java
@@ -1,0 +1,15 @@
+package com.example.feelsun.config.errors.exception;
+
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import lombok.Getter;
+
+@Getter
+public class Exception403 extends RuntimeException {
+    public Exception403(String message) {
+        super(message);
+    }
+
+    public ApiResponseBuilder.ApiResponse<?> body(){
+        return ApiResponseBuilder.error(getMessage());
+    }
+}

--- a/src/main/java/com/example/feelsun/config/errors/exception/Exception404.java
+++ b/src/main/java/com/example/feelsun/config/errors/exception/Exception404.java
@@ -1,0 +1,15 @@
+package com.example.feelsun.config.errors.exception;
+
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import lombok.Getter;
+
+@Getter
+public class Exception404 extends RuntimeException {
+    public Exception404(String message) {
+        super(message);
+    }
+
+    public ApiResponseBuilder.ApiResponse<?> body(){
+        return ApiResponseBuilder.error(getMessage());
+    }
+}

--- a/src/main/java/com/example/feelsun/config/errors/exception/Exception500.java
+++ b/src/main/java/com/example/feelsun/config/errors/exception/Exception500.java
@@ -1,0 +1,15 @@
+package com.example.feelsun.config.errors.exception;
+
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import lombok.Getter;
+
+@Getter
+public class Exception500 extends RuntimeException {
+    public Exception500(String message) {
+        super(message);
+    }
+
+    public ApiResponseBuilder.ApiResponse<?> body() {
+        return ApiResponseBuilder.error(getMessage());
+    }
+}

--- a/src/main/java/com/example/feelsun/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/feelsun/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.example.feelsun.config.jwt;
+
+import com.example.feelsun.config.errors.exception.Exception401;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        String exception = (String) request.getAttribute("exception");
+
+        if (exception == null) {
+            setResponse(response, "로그인이 필요합니다.");
+        } else if (exception.equals("유효하지 않은 JWT 토큰 서명입니다.")) {
+            setResponse(response, "유효하지 않은 JWT 토큰 서명입니다.");
+        } else if (exception.equals("손상된 JWT 토큰입니다.")) {
+            setResponse(response, "손상된 JWT 토큰입니다.");
+        } else if (exception.equals("만료된 JWT 토큰입니다.")) {
+            setResponse(response, "만료된 JWT 토큰입니다.");
+        } else if (exception.equals("지원하지 않는 JWT 토큰입니다.")) {
+            setResponse(response, "지원하지 않는 JWT 토큰입니다.");
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, String message) throws IOException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ObjectMapper om = new ObjectMapper();
+        String responseBody = om.writeValueAsString(new Exception401(message).body());
+        response.getWriter().println(responseBody);
+    }
+}

--- a/src/main/java/com/example/feelsun/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/feelsun/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.example.feelsun.config.jwt;
+
+import com.example.feelsun.config.auth.PrincipalUserDetailsService;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtProvider.resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            try {
+                token = token.split(" ")[1].trim();
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (SignatureException e) {
+                request.setAttribute("exception", "유효하지 않은 JWT 토큰 서명입니다.");
+            } catch (MalformedJwtException e) {
+                request.setAttribute("exception", "손상된 JWT 토큰입니다.");
+            } catch (ExpiredJwtException e) {
+                request.setAttribute("exception", "만료된 JWT 토큰입니다.");
+            } catch (UnsupportedJwtException e) {
+                request.setAttribute("exception", "지원하지 않는 JWT 토큰입니다.");
+            } catch (IllegalArgumentException e) {
+                request.setAttribute("excepiton","JWT 토큰 내에 정보가 없습니다.");
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/example/feelsun/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/feelsun/config/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,6 +23,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Optional;
 
+@Slf4j
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -37,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtProvider.validateToken(token)) {
             try {
+                log.info("token : " + token);
                 token = token.split(" ")[1].trim();
                 Authentication authentication = jwtProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/example/feelsun/config/jwt/JwtProvider.java
+++ b/src/main/java/com/example/feelsun/config/jwt/JwtProvider.java
@@ -26,6 +26,8 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String salt;
 
+    public static final String TOKEN_PREFIX = "Bearer ";
+
     private Key secretKey;
 
     // 만료시간 1hour
@@ -39,9 +41,8 @@ public class JwtProvider {
     }
 
     // 토큰 생성
-    public String createToken(String identity, String role) {
+    public String createToken(String identity) {
         Claims claims = Jwts.claims().setSubject(identity);
-        claims.put("role", role);
         Date now = new Date();
 
         return Jwts.builder()

--- a/src/main/java/com/example/feelsun/config/jwt/JwtProvider.java
+++ b/src/main/java/com/example/feelsun/config/jwt/JwtProvider.java
@@ -41,8 +41,10 @@ public class JwtProvider {
     }
 
     // 토큰 생성
-    public String createToken(String identity) {
+    public String createToken(String identity, String role, String nickname) {
         Claims claims = Jwts.claims().setSubject(identity);
+        claims.put("role", role);
+        claims.put("nickname", nickname);
         Date now = new Date();
 
         return Jwts.builder()

--- a/src/main/java/com/example/feelsun/config/jwt/JwtProvider.java
+++ b/src/main/java/com/example/feelsun/config/jwt/JwtProvider.java
@@ -1,0 +1,100 @@
+package com.example.feelsun.config.jwt;
+
+import com.example.feelsun.config.auth.PrincipalUserDetailsService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String salt;
+
+    private Key secretKey;
+
+    // 만료시간 1hour
+    private final Long exp = 1000L * 60 * 60;
+
+    private final PrincipalUserDetailsService userDetailsService;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Keys.hmacShaKeyFor(salt.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 토큰 생성
+    public String createToken(String identity, String role) {
+        Claims claims = Jwts.claims().setSubject(identity);
+        claims.put("role", role);
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + exp))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 권한 정보 획득 + Spring Security 인증 과정에서 권한 확인을 위한 기능
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getIdentity(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    // Token 에 담겨있는 유저 Identity get
+    public String getIdentity(String token) {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    // Authorization Header 를 통해 인증
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("Authorization");
+    }
+
+    // Token 검증
+    public boolean validateToken(String token) {
+        try {
+            // Bearer 검증 + equalsIgnoreCase()를 사용하여 대소문자 구분없이 비교
+            if (!token.substring(0, "BEARER ".length()).equalsIgnoreCase("BEARER ")) {
+                return false;
+            } else {
+                token = token.split(" ")[1].trim();
+            }
+
+            Jws<Claims> claims = Jwts
+                    .parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+
+            // 만료되었는지 확인 -> 만료라면 false, 만료 전이라면 true
+            return !claims.getBody().getExpiration().before(new Date());
+
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenResponse.java
+++ b/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenResponse.java
@@ -3,15 +3,14 @@ package com.example.feelsun.config.jwt.refreshToken;
 import lombok.Getter;
 import lombok.Setter;
 
+@Getter
+@Setter
 public class RefreshTokenResponse {
 
-    @Getter
-    @Setter
-    public static class RefreshTokenResponseDTO {
         private String accessToken;
 
-        public RefreshTokenResponseDTO(String accessToken) {
+        public RefreshTokenResponse(String accessToken) {
             this.accessToken = accessToken;
         }
-    }
+
 }

--- a/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenResponse.java
+++ b/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenResponse.java
@@ -1,0 +1,17 @@
+package com.example.feelsun.config.jwt.refreshToken;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class RefreshTokenResponse {
+
+    @Getter
+    @Setter
+    public static class RefreshTokenResponseDTO {
+        private String accessToken;
+
+        public RefreshTokenResponseDTO(String accessToken) {
+            this.accessToken = accessToken;
+        }
+    }
+}

--- a/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenService.java
+++ b/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenService.java
@@ -1,0 +1,33 @@
+package com.example.feelsun.config.jwt.refreshToken;
+
+
+import com.example.feelsun.config.jwt.JwtProvider;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Transactional
+@Service
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RefreshTokenService(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 리프래쉬 토큰 저장
+    @Transactional
+    public void saveRefreshToken(String identity, String refreshToken) {
+        redisTemplate.opsForValue().set(identity, refreshToken, Duration.ofDays(7)); // 리프래쉬 토큰 유효 기간 7일
+    }
+
+    // 리프래쉬 토큰 삭제
+    @Transactional
+    public void deleteRefreshToken(String identity) {
+        redisTemplate.delete(identity);
+    }
+
+}

--- a/src/main/java/com/example/feelsun/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/feelsun/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.example.feelsun.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/feelsun/config/redis/RedisService.java
+++ b/src/main/java/com/example/feelsun/config/redis/RedisService.java
@@ -1,0 +1,69 @@
+package com.example.feelsun.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // key 와 value 를 저장하는 메소드
+    public void setValues(String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    // key, value, 만료시간을 함게 저장하고 싶은 경우 사용하는 메소드
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    // key 파라미터를 활용하여 value 데이터를 조회하는 메소드
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValues(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/src/main/java/com/example/feelsun/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/feelsun/config/security/SecurityConfig.java
@@ -55,7 +55,9 @@ public class SecurityConfig {
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정
                 .formLogin(AbstractHttpConfigurer::disable) // form login 사용 X
                 .httpBasic(AbstractHttpConfigurer::disable) // http basic 사용 X
-                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll()) // 아직 설계한 API 가 없으니 모두 허용
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/test/**").authenticated() // jwt 인증 테스트
+                        .anyRequest().permitAll()) // 아직 설계한 API 가 없으니 모두 허용
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(
                                 XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))

--- a/src/main/java/com/example/feelsun/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/feelsun/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.feelsun.config.security;
 
+import com.example.feelsun.config.jwt.JwtAuthenticationEntryPoint;
+import com.example.feelsun.config.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +11,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -18,6 +21,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter; // JwtAuthenticationFilter 주입
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint; // JWTAuthenticationEntryPoint 주입
+
 
     // 비밀번호 암호화
     @Bean
@@ -44,6 +51,7 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 X
+                .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정
                 .formLogin(AbstractHttpConfigurer::disable) // form login 사용 X
                 .httpBasic(AbstractHttpConfigurer::disable) // http basic 사용 X
@@ -51,6 +59,8 @@ public class SecurityConfig {
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(
                                 XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)) // jwt 인증 예외 처리
                 .build();
 
     }

--- a/src/main/java/com/example/feelsun/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/feelsun/config/security/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.example.feelsun.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@EnableMethodSecurity
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig {
+
+    // 비밀번호 암호화
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    // CORS 설정
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*"); // 모든 출처 허용
+        configuration.addAllowedHeader("*"); // 모든 요청 헤더 허용
+        configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        configuration.addExposedHeader("Authorization"); // "Authorization" 응답 헤더 노출
+        configuration.setAllowCredentials(true); // 쿠키 및 인증 정보 허용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 CORS 설정 적용
+        return source;
+    }
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 X
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정
+                .formLogin(AbstractHttpConfigurer::disable) // form login 사용 X
+                .httpBasic(AbstractHttpConfigurer::disable) // http basic 사용 X
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll()) // 아직 설계한 API 가 없으니 모두 허용
+                .headers((headers) -> headers
+                        .addHeaderWriter(new XFrameOptionsHeaderWriter(
+                                XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/feelsun/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/feelsun/config/swagger/SwaggerConfig.java
@@ -28,8 +28,8 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("필선 Project API")
-                .description("필선 프로젝트 API 명세서입니다.")
+                .title("원해빗 Project API")
+                .description("원해빗 프로젝트 API 명세서입니다.")
                 .version("1.0.0");
     }
 }

--- a/src/main/java/com/example/feelsun/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/feelsun/config/swagger/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.example.feelsun.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "authorization";	// 추가
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("필선 Project API")
+                .description("필선 프로젝트 API 명세서입니다.")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/example/feelsun/config/utils/ApiResponseBuilder.java
+++ b/src/main/java/com/example/feelsun/config/utils/ApiResponseBuilder.java
@@ -1,0 +1,39 @@
+package com.example.feelsun.config.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+public class ApiResponseBuilder {
+
+    private static final String SUCCESS_STATUS = "success";
+    private static final String FAIL_STATUS = "fail";
+    private static final String ERROR_STATUS = "error";
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class ApiResponse<T> {
+        private final String status;
+        private final T data;
+        private final String message;
+    }
+    // 성공 후 응답값 ( response ) 에 데이터를 넣고 싶을 때 사용
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(SUCCESS_STATUS, data, null);
+    }
+    // 성공 후 아무런 값도 넣지 않고 싶을 때 사용
+    public static <T> ApiResponse<T> successWithNoContent() {
+        return new ApiResponse<>(SUCCESS_STATUS, null, null);
+    }
+    // 비즈니스 로직 상 실패했을 때 사용
+    public static ApiResponse<?> fail(Map<String, String> errors, String message) {
+        return new ApiResponse<>(FAIL_STATUS, errors, message);
+    }
+    // 에러 발생 시 에러메시지를 넣고 싶을 때 사용
+    public static ApiResponse<?> error(String message) {
+        return new ApiResponse<>(ERROR_STATUS, null, message);
+    }
+}

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -2,7 +2,7 @@ package com.example.feelsun.controller;
 
 import com.example.feelsun.config.errors.exception.Exception401;
 import com.example.feelsun.config.jwt.JwtProvider;
-import com.example.feelsun.config.jwt.refreshToken.RefreshTokenResponse.*;
+import com.example.feelsun.config.jwt.refreshToken.RefreshTokenResponse;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.domain.User;
 import com.example.feelsun.repository.UserJpaRepository;
@@ -34,7 +34,7 @@ public class AuthController {
     @Operation(summary = "토큰 재발급", description = "토큰 재발급을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = RefreshTokenResponseDTO.class)))
+                    schema = @Schema(implementation = RefreshTokenResponse.class)))
     @PostMapping("/refresh-token")
     public ResponseEntity<?> refreshToken(@RequestBody @Valid RefreshTokenRequest requestDTO, Errors errors) {
         String refreshToken = requestDTO.getRefreshToken();
@@ -54,7 +54,7 @@ public class AuthController {
 
         String newAccessToken = jwtProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
 
-        RefreshTokenResponseDTO refreshTokenResponseDTO = new RefreshTokenResponseDTO(newAccessToken);
+        RefreshTokenResponse refreshTokenResponseDTO = new RefreshTokenResponse(newAccessToken);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(refreshTokenResponseDTO));
     }

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -6,17 +6,19 @@ import com.example.feelsun.config.jwt.refreshToken.RefreshTokenResponse.*;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.domain.User;
 import com.example.feelsun.repository.UserJpaRepository;
+import com.example.feelsun.request.AuthRequest.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,28 +31,21 @@ public class AuthController {
     private final JwtProvider jwtProvider;
     private final UserJpaRepository userJpaRepository;
 
-    private String extractRefreshTokenFromCookies(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("refresh-token".equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null; // 쿠키에서 리프래쉬 토큰을 찾을 수 없는 경우
-    }
-
     @Operation(summary = "토큰 재발급", description = "토큰 재발급을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = RefreshTokenResponseDTO.class)))
     @PostMapping("/refresh-token")
-    public ResponseEntity<?> refreshToken(HttpServletRequest request) {
-        String refreshToken = extractRefreshTokenFromCookies(request);
+    public ResponseEntity<?> refreshToken(@RequestBody @Valid RefreshTokenRequest requestDTO, Errors errors) {
+        String refreshToken = requestDTO.getRefreshToken();
 
-        if (refreshToken == null || !jwtProvider.validateRefreshToken(refreshToken)) {
-            throw new Exception401("리프래쉬 토큰이 유효하지 않습니다.");
+        if (refreshToken == null) {
+            throw new Exception401("리프래쉬 토큰이 존재하지 않습니다.");
+        }
+
+        // refresh token 유효성 검사
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new Exception401("유효하지 않은 리프래쉬 토큰입니다.");
         }
 
         String userId = jwtProvider.getIdentity(refreshToken);

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -1,0 +1,2 @@
+package com.example.feelsun.controller;public class AuthController {
+}

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -1,23 +1,26 @@
 package com.example.feelsun.controller;
 
-import com.example.feelsun.config.auth.PrincipalUserDetailsService;
 import com.example.feelsun.config.errors.exception.Exception401;
 import com.example.feelsun.config.jwt.JwtProvider;
-import com.example.feelsun.config.jwt.refreshToken.RefreshTokenService;
+import com.example.feelsun.config.jwt.refreshToken.RefreshTokenResponse.*;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.domain.User;
 import com.example.feelsun.repository.UserJpaRepository;
-import com.example.feelsun.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "RefreshToken", description = "Refresh-Token API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -38,6 +41,10 @@ public class AuthController {
         return null; // 쿠키에서 리프래쉬 토큰을 찾을 수 없는 경우
     }
 
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = RefreshTokenResponseDTO.class)))
     @PostMapping("/refresh-token")
     public ResponseEntity<?> refreshToken(HttpServletRequest request) {
         String refreshToken = extractRefreshTokenFromCookies(request);
@@ -52,7 +59,9 @@ public class AuthController {
 
         String newAccessToken = jwtProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
 
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(newAccessToken));
+        RefreshTokenResponseDTO refreshTokenResponseDTO = new RefreshTokenResponseDTO(newAccessToken);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(refreshTokenResponseDTO));
     }
 
 }

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -1,2 +1,58 @@
-package com.example.feelsun.controller;public class AuthController {
+package com.example.feelsun.controller;
+
+import com.example.feelsun.config.auth.PrincipalUserDetailsService;
+import com.example.feelsun.config.errors.exception.Exception401;
+import com.example.feelsun.config.jwt.JwtProvider;
+import com.example.feelsun.config.jwt.refreshToken.RefreshTokenService;
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import com.example.feelsun.domain.User;
+import com.example.feelsun.repository.UserJpaRepository;
+import com.example.feelsun.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+    private final UserJpaRepository userJpaRepository;
+
+    private String extractRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh-token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null; // 쿠키에서 리프래쉬 토큰을 찾을 수 없는 경우
+    }
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<?> refreshToken(HttpServletRequest request) {
+        String refreshToken = extractRefreshTokenFromCookies(request);
+
+        if (refreshToken == null || !jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new Exception401("리프래쉬 토큰이 유효하지 않습니다.");
+        }
+
+        String userId = jwtProvider.getIdentity(refreshToken);
+        User user = userJpaRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new Exception401("유저를 찾을 수 없습니다."));
+
+        String newAccessToken = jwtProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(newAccessToken));
+    }
+
 }

--- a/src/main/java/com/example/feelsun/controller/TestController.java
+++ b/src/main/java/com/example/feelsun/controller/TestController.java
@@ -1,2 +1,22 @@
-package com.example.feelsun.controller;public class TestController {
+package com.example.feelsun.controller;
+
+import com.example.feelsun.config.auth.PrincipalUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TestController {
+
+    @RequestMapping("/test")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> tokenTest(@AuthenticationPrincipal PrincipalUserDetails principalUserDetails) {
+        return ResponseEntity.status(HttpStatus.OK).body(principalUserDetails.getUser());
+    }
 }

--- a/src/main/java/com/example/feelsun/controller/TestController.java
+++ b/src/main/java/com/example/feelsun/controller/TestController.java
@@ -1,11 +1,14 @@
 package com.example.feelsun.controller;
 
 import com.example.feelsun.config.auth.PrincipalUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,7 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class TestController {
 
-    @RequestMapping("/test")
+    @Operation(summary = "토큰 테스트", description = "토큰 테스트를 진행합니다.")
+    @GetMapping("/test")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> tokenTest(@AuthenticationPrincipal PrincipalUserDetails principalUserDetails) {
         return ResponseEntity.status(HttpStatus.OK).body(principalUserDetails.getUser());

--- a/src/main/java/com/example/feelsun/controller/TestController.java
+++ b/src/main/java/com/example/feelsun/controller/TestController.java
@@ -1,0 +1,2 @@
+package com.example.feelsun.controller;public class TestController {
+}

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.example.feelsun.controller;
+
+import com.example.feelsun.config.utils.ApiResponseBuilder;
+import com.example.feelsun.request.UserRequest.*;
+import com.example.feelsun.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO, Errors errors) {
+        userService.signup(requestDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.successWithNoContent());
+    }
+}

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.feelsun.controller;
 
+import com.example.feelsun.config.errors.exception.Exception400;
 import com.example.feelsun.config.jwt.JwtProvider;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.request.UserRequest.*;
@@ -46,5 +47,27 @@ public class UserController {
     public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors) {
         UserLoginResponseWithToken loginDTO = userService.login(requestDTO);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO));
+    }
+
+    @PostMapping("/check-username")
+    public ResponseEntity<?> checkUsername(@RequestBody @Valid UserCheckUsernameRequest requestDTO, Errors errors) {
+        boolean isExists = userService.checkUsername(requestDTO);
+
+        if (isExists) {
+            throw new Exception400(null, "이미 사용중인 아이디입니다.");
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success("사용 가능한 아이디입니다."));
+    }
+
+    @PostMapping("/check-nickname")
+    public ResponseEntity<?> checkNickname(@RequestBody @Valid UserCheckNicknameRequest requestDTO, Errors errors) {
+        boolean isExists = userService.checkNickname(requestDTO);
+
+        if (isExists) {
+            throw new Exception400(null, "이미 사용중인 닉네임입니다.");
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success("사용 가능한 닉네임입니다."));
     }
 }

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -5,6 +5,10 @@ import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.request.UserRequest.*;
 import com.example.feelsun.response.UserResponse.*;
 import com.example.feelsun.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -26,12 +30,18 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "회원가입 성공")
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO) {
         userService.signup(requestDTO);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.successWithNoContent());
     }
 
+    @Operation(summary = "로그인", description = "로그인을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = UserLoginResponse.class)))
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors, HttpServletResponse response) {
         UserLoginResponseWithToken loginDTO = userService.login(requestDTO);

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
     @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "회원가입 성공")
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO) {
+    public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO, Errors errors) {
         userService.signup(requestDTO);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.successWithNoContent());
     }

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -1,11 +1,16 @@
 package com.example.feelsun.controller;
 
+import com.example.feelsun.config.jwt.JwtProvider;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.request.UserRequest.*;
+import com.example.feelsun.response.UserResponse.*;
 import com.example.feelsun.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
@@ -22,8 +27,20 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO, Errors errors) {
+    public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO) {
         userService.signup(requestDTO);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.successWithNoContent());
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors, HttpServletResponse response) {
+        UserLoginResponseWithToken loginDTO = userService.login(requestDTO);
+
+        // jwt 토큰 쿠키에 담기
+        String accessToken = JwtProvider.TOKEN_PREFIX + loginDTO.getToken();
+
+        response.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO.getLoginResponseDTO()));
     }
 }

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -36,10 +36,14 @@ public class UserController {
     public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors, HttpServletResponse response) {
         UserLoginResponseWithToken loginDTO = userService.login(requestDTO);
 
-        // jwt 토큰 쿠키에 담기
-        String accessToken = JwtProvider.TOKEN_PREFIX + loginDTO.getToken();
+        String accessToken = JwtProvider.TOKEN_PREFIX + loginDTO.getAccessToken();
 
         response.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
+
+        Cookie cookie = new Cookie("refresh-token", loginDTO.getRefreshToken());
+        cookie.setHttpOnly(true); // JS를 통한 접근 방지
+        cookie.setPath("/"); // 쿠키를 전송할 경로
+        response.addCookie(cookie);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO.getLoginResponseDTO()));
     }

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -43,18 +43,8 @@ public class UserController {
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = UserLoginResponse.class)))
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors, HttpServletResponse response) {
+    public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors) {
         UserLoginResponseWithToken loginDTO = userService.login(requestDTO);
-
-        String accessToken = JwtProvider.TOKEN_PREFIX + loginDTO.getAccessToken();
-
-        response.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
-
-        Cookie cookie = new Cookie("refresh-token", loginDTO.getRefreshToken());
-        cookie.setHttpOnly(true); // JS를 통한 접근 방지
-        cookie.setPath("/"); // 쿠키를 전송할 경로
-        response.addCookie(cookie);
-
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO.getLoginResponseDTO()));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO));
     }
 }

--- a/src/main/java/com/example/feelsun/domain/User.java
+++ b/src/main/java/com/example/feelsun/domain/User.java
@@ -14,7 +14,7 @@ public class User {
     private Integer id;
 
     @Column(nullable = false, unique = true)
-    private String email;
+    private String username;
 
     @Column(nullable = false)
     private String password;
@@ -22,32 +22,16 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
-    private String profileImage;
-
-    @Column(nullable = false)
-    private String school;
-
-    @Column(nullable = false)
-    private String major;
-
-    @Column(nullable = false)
-    private String grade;
-
     @Enumerated(EnumType.STRING)
     private UserEnum role;
 
     @Builder
-    public User(String email, String password, String nickname, String school, String major, String grade, UserEnum role) {
-        this.email = email;
+    public User(String username, String password, String nickname, UserEnum role) {
+        this.username = username;
         this.password = password;
         this.nickname = nickname;
-        this.school = school;
-        this.major = major;
-        this.grade = grade;
         this.role = role;
     }
-
-    //TO-DO : 공부지수 등 게임적인 요소를 추가할 경우, User 도메인에 필요한 필드 추가
 
 }
 

--- a/src/main/java/com/example/feelsun/domain/User.java
+++ b/src/main/java/com/example/feelsun/domain/User.java
@@ -1,0 +1,53 @@
+package com.example.feelsun.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String profileImage;
+
+    @Column(nullable = false)
+    private String school;
+
+    @Column(nullable = false)
+    private String major;
+
+    @Column(nullable = false)
+    private String grade;
+
+    @Enumerated(EnumType.STRING)
+    private UserEnum role;
+
+    @Builder
+    public User(String email, String password, String nickname, String school, String major, String grade, UserEnum role) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.school = school;
+        this.major = major;
+        this.grade = grade;
+        this.role = role;
+    }
+
+    //TO-DO : 공부지수 등 게임적인 요소를 추가할 경우, User 도메인에 필요한 필드 추가
+
+}
+

--- a/src/main/java/com/example/feelsun/domain/UserEnum.java
+++ b/src/main/java/com/example/feelsun/domain/UserEnum.java
@@ -1,0 +1,16 @@
+package com.example.feelsun.domain;
+
+public enum UserEnum {
+    USER("사용자"),
+    ADMIN("관리자");
+    private final String description;
+
+    UserEnum (String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
@@ -7,4 +7,8 @@ import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.example.feelsun.repository;
+
+import com.example.feelsun.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/example/feelsun/request/AuthRequest.java
+++ b/src/main/java/com/example/feelsun/request/AuthRequest.java
@@ -1,0 +1,15 @@
+package com.example.feelsun.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+public class AuthRequest {
+
+    @Getter
+    @Setter
+    public static class RefreshTokenRequest {
+        @NotNull(message = "리프레시 토큰은 필수 입력 값입니다.")
+        private String refreshToken;
+    }
+}

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -12,27 +12,18 @@ public class UserRequest {
     @Setter
     public static class UserSignUpRequest {
 
-        @NotNull(message = "이메일은 필수 입력 값입니다.")
-        private String email;
+        @NotNull(message = "유저 아이디는 필수 입력 값입니다.")
+        private String username;
         @NotNull(message = "비밀번호는 필수 입력 값입니다.")
         private String password;
         @NotNull(message = "닉네임은 필수 입력 값입니다.")
         private String nickname;
-        @NotNull(message = "학교는 필수 입력 값입니다.")
-        private String school;
-        @NotNull(message = "전공은 필수 입력 값입니다.")
-        private String major;
-        @NotNull(message = "학년은 필수 입력 값입니다.")
-        private String grade;
 
         public User toEntity(UserEnum userEnum) {
             return User.builder()
-                    .email(email)
+                    .username(username)
                     .password(password)
                     .nickname(nickname)
-                    .school(school)
-                    .major(major)
-                    .grade(grade)
                     .role(userEnum)
                     .build();
         }

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -32,8 +32,8 @@ public class UserRequest {
     @Getter
     @Setter
     public static class UserLoginRequest {
-        @NotNull(message = "이메일은 필수 입력 값입니다.")
-        private String email;
+        @NotNull(message = "유저 아이디는 필수 입력 값입니다.")
+        private String username;
         @NotNull(message = "비밀번호는 필수 입력 값입니다.")
         private String password;
     }

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -1,0 +1,40 @@
+package com.example.feelsun.request;
+
+import com.example.feelsun.domain.User;
+import com.example.feelsun.domain.UserEnum;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+public class UserRequest {
+
+    @Getter
+    @Setter
+    public static class UserSignUpRequest {
+
+        @NotNull(message = "이메일은 필수 입력 값입니다.")
+        private String email;
+        @NotNull(message = "비밀번호는 필수 입력 값입니다.")
+        private String password;
+        @NotNull(message = "닉네임은 필수 입력 값입니다.")
+        private String nickname;
+        @NotNull(message = "학교는 필수 입력 값입니다.")
+        private String school;
+        @NotNull(message = "전공은 필수 입력 값입니다.")
+        private String major;
+        @NotNull(message = "학년은 필수 입력 값입니다.")
+        private String grade;
+
+        public User toEntity(UserEnum userEnum) {
+            return User.builder()
+                    .email(email)
+                    .password(password)
+                    .nickname(nickname)
+                    .school(school)
+                    .major(major)
+                    .grade(grade)
+                    .role(userEnum)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -43,4 +43,19 @@ public class UserRequest {
         @NotNull(message = "비밀번호는 필수 입력 값입니다.")
         private String password;
     }
+
+    @Getter
+    @Setter
+    public static class UserCheckUsernameRequest {
+        @NotNull(message = "유저 아이디는 필수 입력 값입니다.")
+        @Size(min = 6, max = 20, message = "아이디는 6자 이상 20자 이하로 입력해주세요.")
+        private String username;
+    }
+
+    @Getter
+    @Setter
+    public static class UserCheckNicknameRequest {
+        @NotNull(message = "닉네임은 필수 입력 값입니다.")
+        private String nickname;
+    }
 }

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -3,6 +3,8 @@ package com.example.feelsun.request;
 import com.example.feelsun.domain.User;
 import com.example.feelsun.domain.UserEnum;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,9 +15,13 @@ public class UserRequest {
     public static class UserSignUpRequest {
 
         @NotNull(message = "유저 아이디는 필수 입력 값입니다.")
+        @Size(min = 6, max = 20, message = "아이디는 6자 이상 20자 이하로 입력해주세요.")
         private String username;
+
         @NotNull(message = "비밀번호는 필수 입력 값입니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*\\W).{8,20}$", message = "비밀번호는 8자 이상 20자 이내이며, 문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다.")
         private String password;
+
         @NotNull(message = "닉네임은 필수 입력 값입니다.")
         private String nickname;
 

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -37,4 +37,13 @@ public class UserRequest {
                     .build();
         }
     }
+
+    @Getter
+    @Setter
+    public static class UserLoginRequest {
+        @NotNull(message = "이메일은 필수 입력 값입니다.")
+        private String email;
+        @NotNull(message = "비밀번호는 필수 입력 값입니다.")
+        private String password;
+    }
 }

--- a/src/main/java/com/example/feelsun/response/UserResponse.java
+++ b/src/main/java/com/example/feelsun/response/UserResponse.java
@@ -23,21 +23,13 @@ public class UserResponse {
     @Setter
     public static class UserLoginResponse {
         private Integer id;
-        private String email;
+        private String username;
         private String nickname;
-        private String profileImage;
-        private String school;
-        private String major;
-        private String grade;
 
-        public UserLoginResponse(Integer id, String email, String nickname, String profileImage, String school, String major, String grade) {
+        public UserLoginResponse(Integer id, String username, String nickname) {
             this.id = id;
-            this.email = email;
+            this.username = username;
             this.nickname = nickname;
-            this.profileImage = profileImage;
-            this.school = school;
-            this.major = major;
-            this.grade = grade;
         }
     }
 }

--- a/src/main/java/com/example/feelsun/response/UserResponse.java
+++ b/src/main/java/com/example/feelsun/response/UserResponse.java
@@ -1,0 +1,8 @@
+package com.example.feelsun.response;
+
+public class UserResponse {
+
+    public static class UserSignUpResponse {
+
+    }
+}

--- a/src/main/java/com/example/feelsun/response/UserResponse.java
+++ b/src/main/java/com/example/feelsun/response/UserResponse.java
@@ -9,11 +9,13 @@ public class UserResponse {
     @Setter
     public static class UserLoginResponseWithToken {
         private UserLoginResponse loginResponseDTO;
-        private String token;
+        private String accessToken;
+        private String refreshToken;
 
-        public UserLoginResponseWithToken(UserLoginResponse loginResponseDTO, String token) {
+        public UserLoginResponseWithToken(UserLoginResponse loginResponseDTO, String accessToken, String refreshToken) {
             this.loginResponseDTO = loginResponseDTO;
-            this.token = token;
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
         }
     }
 

--- a/src/main/java/com/example/feelsun/response/UserResponse.java
+++ b/src/main/java/com/example/feelsun/response/UserResponse.java
@@ -1,8 +1,41 @@
 package com.example.feelsun.response;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class UserResponse {
 
-    public static class UserSignUpResponse {
+    @Getter
+    @Setter
+    public static class UserLoginResponseWithToken {
+        private UserLoginResponse loginResponseDTO;
+        private String token;
 
+        public UserLoginResponseWithToken(UserLoginResponse loginResponseDTO, String token) {
+            this.loginResponseDTO = loginResponseDTO;
+            this.token = token;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class UserLoginResponse {
+        private Integer id;
+        private String email;
+        private String nickname;
+        private String profileImage;
+        private String school;
+        private String major;
+        private String grade;
+
+        public UserLoginResponse(Integer id, String email, String nickname, String profileImage, String school, String major, String grade) {
+            this.id = id;
+            this.email = email;
+            this.nickname = nickname;
+            this.profileImage = profileImage;
+            this.school = school;
+            this.major = major;
+            this.grade = grade;
+        }
     }
 }

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -1,8 +1,13 @@
 package com.example.feelsun.service;
 
+import com.example.feelsun.config.errors.exception.Exception400;
+import com.example.feelsun.config.errors.exception.Exception404;
+import com.example.feelsun.config.jwt.JwtProvider;
+import com.example.feelsun.domain.User;
 import com.example.feelsun.domain.UserEnum;
 import com.example.feelsun.repository.UserJpaRepository;
 import com.example.feelsun.request.UserRequest.*;
+import com.example.feelsun.response.UserResponse.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,11 +20,29 @@ public class UserService {
 
     private final PasswordEncoder passwordEncoder;
     private final UserJpaRepository userJpaRepository;
+    private final JwtProvider tokenProvider;
 
+    @Transactional
     public void signup(UserSignUpRequest requestDTO) {
         // 비밀번호 암호화
         requestDTO.setPassword(passwordEncoder.encode(requestDTO.getPassword()));
         // 저장
         userJpaRepository.save(requestDTO.toEntity(UserEnum.USER));
+    }
+
+    @Transactional
+    public UserLoginResponseWithToken login(UserLoginRequest requestDTO) {
+        User user = userJpaRepository.findByEmail(requestDTO.getEmail())
+                .orElseThrow(() -> new Exception400(null, "아이디 또는 비밀번호가 일치하지 않습니다."));
+
+        if (!passwordEncoder.matches(requestDTO.getPassword(), user.getPassword())) {
+            throw new Exception400(null, "아이디 또는 비밀번호가 일치하지 않습니다.");
+        }
+
+        String token = tokenProvider.createToken(user.getEmail());
+
+        UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getEmail(), user.getNickname(), user.getProfileImage(), user.getSchool(), user.getMajor(), user.getGrade());
+
+        return new UserLoginResponseWithToken(loginResponseDTO, token);
     }
 }

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -1,0 +1,25 @@
+package com.example.feelsun.service;
+
+import com.example.feelsun.domain.UserEnum;
+import com.example.feelsun.repository.UserJpaRepository;
+import com.example.feelsun.request.UserRequest.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserJpaRepository userJpaRepository;
+
+    public void signup(UserSignUpRequest requestDTO) {
+        // 비밀번호 암호화
+        requestDTO.setPassword(passwordEncoder.encode(requestDTO.getPassword()));
+        // 저장
+        userJpaRepository.save(requestDTO.toEntity(UserEnum.USER));
+    }
+}

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -13,6 +13,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -51,5 +53,13 @@ public class UserService {
         UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getUsername(), user.getNickname());
 
         return new UserLoginResponseWithToken(loginResponseDTO, accessToken, refreshToken);
+    }
+
+    public boolean checkUsername(UserCheckUsernameRequest requestDTO) {
+        return userJpaRepository.existsByUsername(requestDTO.getUsername());
+    }
+
+    public boolean checkNickname(UserCheckNicknameRequest requestDTO) {
+        return userJpaRepository.existsByNickname(requestDTO.getNickname());
     }
 }

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
             throw new Exception400(null, "아이디 또는 비밀번호가 일치하지 않습니다.");
         }
 
-        String token = tokenProvider.createToken(user.getEmail());
+        String token = tokenProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
 
         UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getEmail(), user.getNickname(), user.getProfileImage(), user.getSchool(), user.getMajor(), user.getGrade());
 

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -1,7 +1,6 @@
 package com.example.feelsun.service;
 
 import com.example.feelsun.config.errors.exception.Exception400;
-import com.example.feelsun.config.errors.exception.Exception404;
 import com.example.feelsun.config.jwt.JwtProvider;
 import com.example.feelsun.config.jwt.refreshToken.RefreshTokenService;
 import com.example.feelsun.domain.User;
@@ -34,14 +33,14 @@ public class UserService {
 
     @Transactional
     public UserLoginResponseWithToken login(UserLoginRequest requestDTO) {
-        User user = userJpaRepository.findByEmail(requestDTO.getEmail())
+        User user = userJpaRepository.findByUsername(requestDTO.getUsername())
                 .orElseThrow(() -> new Exception400(null, "아이디 또는 비밀번호가 일치하지 않습니다."));
 
         if (!passwordEncoder.matches(requestDTO.getPassword(), user.getPassword())) {
             throw new Exception400(null, "아이디 또는 비밀번호가 일치하지 않습니다.");
         }
 
-        String accessToken = tokenProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
+        String accessToken = JwtProvider.TOKEN_PREFIX + tokenProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
 
         // 리프래쉬 토큰 생성
         String refreshToken = tokenProvider.createRefreshToken(user.getId().toString());
@@ -49,7 +48,7 @@ public class UserService {
         // 리프래쉬 토큰을 Redis에 저장
         refreshTokenService.saveRefreshToken(user.getId().toString(), refreshToken);
 
-        UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getEmail(), user.getNickname(), user.getProfileImage(), user.getSchool(), user.getMajor(), user.getGrade());
+        UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getUsername(), user.getNickname());
 
         return new UserLoginResponseWithToken(loginResponseDTO, accessToken, refreshToken);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,0 @@
-spring.application.name=feelsun

--- a/src/test/java/com/example/feelsun/redis/RedisTest.java
+++ b/src/test/java/com/example/feelsun/redis/RedisTest.java
@@ -1,7 +1,6 @@
 package com.example.feelsun.redis;
 
 import com.example.feelsun.config.redis.RedisService;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/example/feelsun/redis/RedisTest.java
+++ b/src/test/java/com/example/feelsun/redis/RedisTest.java
@@ -1,0 +1,85 @@
+package com.example.feelsun.redis;
+
+import com.example.feelsun.config.redis.RedisService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest
+class RedisTest {
+    final String KEY = "key";
+    final String VALUE = "value";
+    final Duration DURATION = Duration.ofMillis(5000);
+
+    @Autowired
+    private RedisService redisService;
+
+    @BeforeEach
+    void shutDown() {
+        redisService.setValues(KEY, VALUE, DURATION);
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisService.deleteValues(KEY);
+    }
+
+    @Test
+    @DisplayName("Redis에 데이터를 저장하면 정상적으로 조회된다.")
+    void saveAndFindTest() throws Exception {
+        // when
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(VALUE).isEqualTo(findValue);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터를 수정할 수 있다.")
+    void updateTest() throws Exception {
+        // given
+        String updateValue = "updateValue";
+        redisService.setValues(KEY, updateValue, DURATION);
+
+        // when
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(updateValue).isEqualTo(findValue);
+        assertThat(VALUE).isNotEqualTo(findValue);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터를 삭제할 수 있다.")
+    void deleteTest() throws Exception {
+        // when
+        redisService.deleteValues(KEY);
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(findValue).isEqualTo("false");
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터는 만료시간이 지나면 삭제된다.")
+    void expiredTest() throws Exception {
+        // when
+        String findValue = redisService.getValues(KEY);
+        await().pollDelay(Duration.ofMillis(6000)).untilAsserted(
+                () -> {
+                    String expiredValue = redisService.getValues(KEY);
+                    assertThat(expiredValue).isNotEqualTo(findValue);
+                    assertThat(expiredValue).isEqualTo("false");
+                }
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

<!--- 작업하신 내용을 간략하게 설명해주세요 -->

1. 유저 아이디 중복 체크 기능 추가
2. 유저 닉네임 중복 체크 기능 추가

## 기타 및 참고 사항

### 유저 아이디 중복체크

1. 글자수 

![유저아이디 중복체크 - 글자수](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/aa291ddf-6cc5-4fbd-913f-4785f387f4da)

2. 중복

![유저아이디 중복체크 - 실패](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/c7f25639-0ebc-4140-bcdd-cfc73fda81c5)

3. 성공

![유저아이디 중복체크 - 성공](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/20c69e7c-7196-456d-af7f-d2673ce0888d)

### 유저 닉네임 중복체크

1. 중복

![닉네임 중복체크 - 중복](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/e87a0128-f6d0-4499-8eeb-13a34748f2b4)

2. 성공

![닉네임 중복체크 - 정상](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/6b3d52dc-c231-4ebc-b9a9-066a86a30c1f)

닉네임도 길이 조정이 필요하다면, 이야기해보고 추가하겠습니다

## 이슈 번호

<!--- 작업을 마친 이슈는 클로즈 해주세요 -->

This closes #15 
