### PR TITLE
유저 아이디, 닉네임 중복체크 기능 추가

### DIFF
--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.feelsun.controller;
 
+import com.example.feelsun.config.errors.exception.Exception400;
 import com.example.feelsun.config.jwt.JwtProvider;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.request.UserRequest.*;
@@ -46,5 +47,27 @@ public class UserController {
     public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors) {
         UserLoginResponseWithToken loginDTO = userService.login(requestDTO);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO));
+    }
+
+    @PostMapping("/check-username")
+    public ResponseEntity<?> checkUsername(@RequestBody @Valid UserCheckUsernameRequest requestDTO, Errors errors) {
+        boolean isExists = userService.checkUsername(requestDTO);
+
+        if (isExists) {
+            throw new Exception400(null, "이미 사용중인 아이디입니다.");
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success("사용 가능한 아이디입니다."));
+    }
+
+    @PostMapping("/check-nickname")
+    public ResponseEntity<?> checkNickname(@RequestBody @Valid UserCheckNicknameRequest requestDTO, Errors errors) {
+        boolean isExists = userService.checkNickname(requestDTO);
+
+        if (isExists) {
+            throw new Exception400(null, "이미 사용중인 닉네임입니다.");
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success("사용 가능한 닉네임입니다."));
     }
 }

--- a/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
@@ -7,4 +7,8 @@ import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -43,4 +43,19 @@ public class UserRequest {
         @NotNull(message = "비밀번호는 필수 입력 값입니다.")
         private String password;
     }
+
+    @Getter
+    @Setter
+    public static class UserCheckUsernameRequest {
+        @NotNull(message = "유저 아이디는 필수 입력 값입니다.")
+        @Size(min = 6, max = 20, message = "아이디는 6자 이상 20자 이하로 입력해주세요.")
+        private String username;
+    }
+
+    @Getter
+    @Setter
+    public static class UserCheckNicknameRequest {
+        @NotNull(message = "닉네임은 필수 입력 값입니다.")
+        private String nickname;
+    }
 }

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -13,6 +13,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -51,5 +53,13 @@ public class UserService {
         UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getUsername(), user.getNickname());
 
         return new UserLoginResponseWithToken(loginResponseDTO, accessToken, refreshToken);
+    }
+
+    public boolean checkUsername(UserCheckUsernameRequest requestDTO) {
+        return userJpaRepository.existsByUsername(requestDTO.getUsername());
+    }
+
+    public boolean checkNickname(UserCheckNicknameRequest requestDTO) {
+        return userJpaRepository.existsByNickname(requestDTO.getNickname());
     }
 }


### PR DESCRIPTION
## 작업 내용

<!--- 작업하신 내용을 간략하게 설명해주세요 -->

1. 유저 아이디 중복 체크 기능 추가
2. 유저 닉네임 중복 체크 기능 추가

## 기타 및 참고 사항

### 유저 아이디 중복체크

1. 글자수 

![유저아이디 중복체크 - 글자수](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/aa291ddf-6cc5-4fbd-913f-4785f387f4da)

2. 중복

![유저아이디 중복체크 - 실패](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/c7f25639-0ebc-4140-bcdd-cfc73fda81c5)

3. 성공

![유저아이디 중복체크 - 성공](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/20c69e7c-7196-456d-af7f-d2673ce0888d)

### 유저 닉네임 중복체크

1. 중복

![닉네임 중복체크 - 중복](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/e87a0128-f6d0-4499-8eeb-13a34748f2b4)

2. 성공

![닉네임 중복체크 - 정상](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/6b3d52dc-c231-4ebc-b9a9-066a86a30c1f)

닉네임도 길이 조정이 필요하다면, 이야기해보고 추가하겠습니다

## 이슈 번호

<!--- 작업을 마친 이슈는 클로즈 해주세요 -->

This closes #15 
