### PR TITLE
회원가입시, 액세스토큰 재발급시 response 값 로그인과 동일하게 나오도록 수정

### DIFF
--- a/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenService.java
+++ b/src/main/java/com/example/feelsun/config/jwt/refreshToken/RefreshTokenService.java
@@ -1,7 +1,12 @@
 package com.example.feelsun.config.jwt.refreshToken;
 
 
+import com.example.feelsun.config.errors.exception.Exception401;
 import com.example.feelsun.config.jwt.JwtProvider;
+import com.example.feelsun.domain.User;
+import com.example.feelsun.repository.UserJpaRepository;
+import com.example.feelsun.request.AuthRequest;
+import com.example.feelsun.response.UserResponse.*;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,9 +18,13 @@ import java.time.Duration;
 public class RefreshTokenService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final JwtProvider jwtProvider;
+    private final UserJpaRepository userJpaRepository;
 
-    public RefreshTokenService(RedisTemplate<String, Object> redisTemplate) {
+    public RefreshTokenService(RedisTemplate<String, Object> redisTemplate, JwtProvider jwtProvider, UserJpaRepository userJpaRepository) {
         this.redisTemplate = redisTemplate;
+        this.jwtProvider = jwtProvider;
+        this.userJpaRepository = userJpaRepository;
     }
 
     // 리프래쉬 토큰 저장
@@ -29,5 +38,31 @@ public class RefreshTokenService {
     public void deleteRefreshToken(String identity) {
         redisTemplate.delete(identity);
     }
+
+    @Transactional
+    public UserLoginResponseWithToken generateToken(AuthRequest.RefreshTokenRequest requestDTO) {
+        String refreshToken = requestDTO.getRefreshToken();
+
+        if (refreshToken == null) {
+            throw new Exception401("리프래쉬 토큰이 존재하지 않습니다.");
+        }
+
+        // refresh token 유효성 검사
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new Exception401("유효하지 않은 리프래쉬 토큰입니다.");
+        }
+
+        String userId = jwtProvider.getIdentity(refreshToken);
+
+        User user = userJpaRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new Exception401("유저를 찾을 수 없습니다."));
+
+        String newAccessToken = jwtProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
+
+        UserLoginResponse loginResponseDTO = new UserLoginResponse(user.getId(), user.getUsername(), user.getNickname());
+
+        return new UserLoginResponseWithToken(loginResponseDTO, newAccessToken, refreshToken);
+    }
+
 
 }

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -3,10 +3,12 @@ package com.example.feelsun.controller;
 import com.example.feelsun.config.errors.exception.Exception401;
 import com.example.feelsun.config.jwt.JwtProvider;
 import com.example.feelsun.config.jwt.refreshToken.RefreshTokenResponse;
+import com.example.feelsun.config.jwt.refreshToken.RefreshTokenService;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.domain.User;
-import com.example.feelsun.repository.UserJpaRepository;
 import com.example.feelsun.request.AuthRequest.*;
+import com.example.feelsun.response.UserResponse.*;
+import com.example.feelsun.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final JwtProvider jwtProvider;
-    private final UserJpaRepository userJpaRepository;
+    private final RefreshTokenService refreshTokenService;
 
     @Operation(summary = "토큰 재발급", description = "토큰 재발급을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
@@ -37,26 +39,10 @@ public class AuthController {
                     schema = @Schema(implementation = RefreshTokenResponse.class)))
     @PostMapping("/refresh-token")
     public ResponseEntity<?> refreshToken(@RequestBody @Valid RefreshTokenRequest requestDTO, Errors errors) {
-        String refreshToken = requestDTO.getRefreshToken();
 
-        if (refreshToken == null) {
-            throw new Exception401("리프래쉬 토큰이 존재하지 않습니다.");
-        }
+        UserLoginResponseWithToken tokenDTO = refreshTokenService.generateToken(requestDTO);
 
-        // refresh token 유효성 검사
-        if (!jwtProvider.validateRefreshToken(refreshToken)) {
-            throw new Exception401("유효하지 않은 리프래쉬 토큰입니다.");
-        }
-
-        String userId = jwtProvider.getIdentity(refreshToken);
-        User user = userJpaRepository.findById(Long.parseLong(userId))
-                .orElseThrow(() -> new Exception401("유저를 찾을 수 없습니다."));
-
-        String newAccessToken = jwtProvider.createToken(user.getId().toString(), user.getRole().toString(), user.getNickname());
-
-        RefreshTokenResponse refreshTokenResponseDTO = new RefreshTokenResponse(newAccessToken);
-
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(refreshTokenResponseDTO));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(tokenDTO));
     }
 
 }

--- a/src/main/java/com/example/feelsun/controller/AuthController.java
+++ b/src/main/java/com/example/feelsun/controller/AuthController.java
@@ -30,13 +30,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class AuthController {
 
-    private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
 
     @Operation(summary = "토큰 재발급", description = "토큰 재발급을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = RefreshTokenResponse.class)))
+                    schema = @Schema(implementation = UserLoginResponseWithToken.class)))
     @PostMapping("/refresh-token")
     public ResponseEntity<?> refreshToken(@RequestBody @Valid RefreshTokenRequest requestDTO, Errors errors) {
 

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -36,7 +36,10 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO, Errors errors) {
         userService.signup(requestDTO);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.successWithNoContent());
+
+        UserLoginResponseWithToken signupDTO = userService.generateToken(requestDTO);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(signupDTO));
     }
 
     @Operation(summary = "로그인", description = "로그인을 진행합니다.")
@@ -49,6 +52,8 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(loginDTO));
     }
 
+    @Operation(summary = "유저 아이디 중복 체크", description = "유저 아이디 중복 체크를 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "사용 가능한 아이디입니다.")
     @PostMapping("/check-username")
     public ResponseEntity<?> checkUsername(@RequestBody @Valid UserCheckUsernameRequest requestDTO, Errors errors) {
         boolean isExists = userService.checkUsername(requestDTO);
@@ -60,6 +65,8 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success("사용 가능한 아이디입니다."));
     }
 
+    @Operation(summary = "유저 닉네임 중복 체크", description = "유저 닉네임 중복 체크를 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "사용 가능한 닉네임입니다.")
     @PostMapping("/check-nickname")
     public ResponseEntity<?> checkNickname(@RequestBody @Valid UserCheckNicknameRequest requestDTO, Errors errors) {
         boolean isExists = userService.checkNickname(requestDTO);

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -32,7 +32,9 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
-    @ApiResponse(responseCode = "200", description = "회원가입 성공")
+    @ApiResponse(responseCode = "200", description = "회원가입 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = UserLoginResponseWithToken.class)))
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody @Valid UserSignUpRequest requestDTO, Errors errors) {
         userService.signup(requestDTO);
@@ -45,7 +47,7 @@ public class UserController {
     @Operation(summary = "로그인", description = "로그인을 진행합니다.")
     @ApiResponse(responseCode = "200", description = "로그인 성공",
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = UserLoginResponse.class)))
+                    schema = @Schema(implementation = UserLoginResponseWithToken.class)))
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest requestDTO, Errors errors) {
         UserLoginResponseWithToken loginDTO = userService.login(requestDTO);

--- a/src/main/java/com/example/feelsun/domain/User.java
+++ b/src/main/java/com/example/feelsun/domain/User.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
@@ -24,6 +28,10 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private UserEnum role;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     @Builder
     public User(String username, String password, String nickname, UserEnum role) {

--- a/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/UserJpaRepository.java
@@ -11,4 +11,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/example/feelsun/request/UserRequest.java
+++ b/src/main/java/com/example/feelsun/request/UserRequest.java
@@ -23,6 +23,7 @@ public class UserRequest {
         private String password;
 
         @NotNull(message = "닉네임은 필수 입력 값입니다.")
+        @Size(max = 8, message = "닉네임은 8자 이하로 입력해주세요.")
         private String nickname;
 
         public User toEntity(UserEnum userEnum) {

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -29,6 +29,14 @@ public class UserService {
     public void signup(UserSignUpRequest requestDTO) {
         // 비밀번호 암호화
         requestDTO.setPassword(passwordEncoder.encode(requestDTO.getPassword()));
+        // 이미 있는 아이디일경우 예외처리
+        userJpaRepository.findByUsername(requestDTO.getUsername()).ifPresent(user -> {
+            throw new Exception400(null, "이미 존재하는 아이디입니다.");
+        });
+        // 이미 있는 닉네임일경우 예외처리
+        userJpaRepository.findByNickname(requestDTO.getNickname()).ifPresent(user -> {
+            throw new Exception400(null, "이미 존재하는 닉네임입니다.");
+        });
         // 저장
         userJpaRepository.save(requestDTO.toEntity(UserEnum.USER));
     }


### PR DESCRIPTION
## 작업 내용

<!--- 작업하신 내용을 간략하게 설명해주세요 -->

1. 회원가입시, 액세스토큰 재발급시 response 값 로그인과 동일하게 나오도록 수정
2. user createdAt 데이터 추가
3. swagger 수정
4. 회원가입시 예외처리 부분 추가 ( 아이디, 닉네임 )

## 기타 및 참고 사항

1. 회원가입 성공

![회원가입 성공](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/02a5ef74-c8d8-42e4-8644-be27e3bb3275)

2. 리프래쉬 토큰을 활용한 액세스 토큰 재발급 성공

![리프래쉬 토큰 성공](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/de24021e-4e2a-4af3-a74c-b212623fbe74)

3. 이 오류문구를 해결하기 위한 예외처리 문구 추가 ( 동일한 아이디, 닉네임 )

이 부분은 이미 POST API 로 팅기지만, 만약 중복처리를 하지 않고 바로 데이터를 보낼 경우를 대비한 예외처리

![오류문구](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/8a74ae01-135e-46f1-a351-9fad3ec42e73)


## 이슈 번호

<!--- 작업을 마친 이슈는 클로즈 해주세요 -->

This closes #18 
