### PR TITLE
[USER] 둘러보기 페이지 - 랜덤 나무 리스트 조회

### DIFF
--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.example.feelsun.controller;
 
+import com.example.feelsun.config.auth.PrincipalUserDetails;
 import com.example.feelsun.config.errors.exception.Exception400;
-import com.example.feelsun.config.jwt.JwtProvider;
 import com.example.feelsun.config.utils.ApiResponseBuilder;
 import com.example.feelsun.request.UserRequest.*;
 import com.example.feelsun.response.UserResponse.*;
@@ -10,23 +10,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
-import org.springframework.http.HttpHeaders;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;
@@ -79,4 +76,17 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success("사용 가능한 닉네임입니다."));
     }
+
+    @Operation(summary = "유저의 나무 랜덤 리스트 조회", description = "유저의 나무 랜덤 리스트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "유저의 나무 랜덤 리스트 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = UserTreeListResponse.class)))
+    @GetMapping("/list")
+    public ResponseEntity<?> getUserTreeList(@AuthenticationPrincipal PrincipalUserDetails principalUserDetails,
+                                             @RequestParam(value = "page", defaultValue = "0") int page,
+                                             @RequestParam(value = "size", defaultValue = "5") int size) {
+        List<UserTreeListResponse> treeListDTO = userService.getUserTreeList(principalUserDetails, page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(treeListDTO));
+    }
+
 }

--- a/src/main/java/com/example/feelsun/domain/Tree.java
+++ b/src/main/java/com/example/feelsun/domain/Tree.java
@@ -1,0 +1,51 @@
+package com.example.feelsun.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "trees")
+public class Tree {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int level;
+
+    @Column(nullable = false)
+    private int experience;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TreeEnum accessLevel;
+
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/feelsun/domain/TreeEnum.java
+++ b/src/main/java/com/example/feelsun/domain/TreeEnum.java
@@ -1,0 +1,15 @@
+package com.example.feelsun.domain;
+
+public enum TreeEnum {
+    FREE("무료"),
+    PAY("유료");
+    private final String description;
+
+    TreeEnum (String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/feelsun/repository/TreeJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/TreeJpaRepository.java
@@ -1,0 +1,16 @@
+package com.example.feelsun.repository;
+
+import com.example.feelsun.domain.Tree;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TreeJpaRepository extends JpaRepository<Tree, Integer> {
+
+    Page<Tree> findAll(Specification<Tree> spec, Pageable pageable);
+}

--- a/src/main/java/com/example/feelsun/response/UserResponse.java
+++ b/src/main/java/com/example/feelsun/response/UserResponse.java
@@ -7,6 +7,18 @@ public class UserResponse {
 
     @Getter
     @Setter
+    public static class UserTreeListResponse {
+        private Integer userId;
+        private Integer treeId;
+        private String habitName;
+        private String treeImageUrl;
+
+    }
+
+
+
+    @Getter
+    @Setter
     public static class UserLoginResponseWithToken {
         private UserLoginResponse loginResponseDTO;
         private String accessToken;

--- a/src/main/resources/db/teardown.sql
+++ b/src/main/resources/db/teardown.sql
@@ -1,0 +1,22 @@
+-- 더미 데이터 작성 파일
+SET REFERENTIAL_INTEGRITY FALSE;
+TRUNCATE TABLE users;
+TRUNCATE TABLE trees;
+SET REFERENTIAL_INTEGRITY TRUE;
+
+INSERT INTO users (username, password, nickname, role, created_at)
+VALUES ('admin', 'admin', 'admin', 'ADMIN', '2021-01-01 00:00:00'),
+       ('user', 'user', 'user', 'USER', '2021-01-01 00:00:00');
+
+INSERT INTO trees (user_id, name, level, experience, image_url, price, access_level, start_date, end_date, created_at)
+VALUES (1, '나무1', 1, 1, 'https://via.placeholder.com/150', 0, 'FREE', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (1, '나무2', 2, 5, 'https://via.placeholder.com/150', 0, 'FREE', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (1, '나무3', 3, 35, 'https://via.placeholder.com/150', 100, 'PAY', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (1, '나무4', 1, 1, 'https://via.placeholder.com/150', 0, 'FREE', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (2, '나무5', 2, 5, 'https://via.placeholder.com/150', 0, 'FREE', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (2, '나무6', 3, 35, 'https://via.placeholder.com/150', 100, 'PAY', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (2, '나무7', 1, 1, 'https://via.placeholder.com/150', 0, 'FREE', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (2, '나무8', 2, 5, 'https://via.placeholder.com/150', 0, 'FREE', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00'),
+       (2, '나무9', 3, 35, 'https://via.placeholder.com/150', 100, 'PAY', '2021-01-01 00:00:00', '2021-12-31 23:59:59', '2021-01-01 00:00:00');
+
+


### PR DESCRIPTION
## 작업 내용

<!--- 작업하신 내용을 간략하게 설명해주세요 -->

1. 나무 엔티티, JPA 추가
2. 유저의 나무 랜덤 리스트를 조회하는 API 작성
3. 더미 테스트 파일 추가

#### Redis 에 임시로 나무의 id 데이터들을 저장한 뒤, 리스트 페이지 API 를 호출할 때 이를 확인 후 redis 안에 없는 데이터만 랜덤하게 조회하는 형식으로 코드를 작성했습니다.

#### 이 경우, 시간이 지나야만이 redis 안에 존재하는 데이터가 사라진다는 이슈가 있어, 히스토리 API 말고 다른 API 를 호출할 때 redis 안에 저장되어있는 history 기록들을 지울 필요가 있습니다.

## 기타 및 참고 사항

총 9개의 더미데이터로 테스트 진행

1. 랜덤하게 데이터를 가져오는 응답값, redis 화면

![랜덤하게 데이터를 가져오는 응답값](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/32ef0625-a7fd-481d-9aef-168ec99a7d39)

![redis 에 임시로 저장](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/f9a7fd1f-701c-4ebe-895d-3826559b394e)

2. 두번째 실행

![2번 조회했을 때](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/4b1ce224-e5ea-48c4-8605-58aae2877847)

![2번 조회 - redis](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/dfcb85e0-3e41-4309-b3e7-312ad1d69fc2)

3. 조회할 수 있는 데이터 전부 조회했을 때

![조회할 수 있는 데이터 전부 조회했음](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_19_BE/assets/111727212/8ecb014b-d9b9-4c2d-97ce-d50108f7187f)


## 이슈 번호

<!--- 작업을 마친 이슈는 클로즈 해주세요 -->

This closes #20 
