### PR TITLE
[USER] 나무 둘러보기 및 상세 페이지 API 삭제

### DIFF
--- a/src/main/java/com/example/feelsun/controller/TreePostController.java
+++ b/src/main/java/com/example/feelsun/controller/TreePostController.java
@@ -61,4 +61,13 @@ public class TreePostController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.successWithNoContent());
     }
 
+    @Operation(summary = "나무 전체 인증글 수를 가져옵니다", description = "나무 전체 인증글 수를 가져옵니다")
+    @ApiResponse(responseCode = "200", description = "나무 전체 인증글 수를 가져옵니다")
+    @GetMapping("/{treeId}/post-counts")
+    public ResponseEntity<?> getTreePostCounts(@PathVariable("treeId") Integer treeId,
+                                               @AuthenticationPrincipal PrincipalUserDetails principalUserDetails) {
+        int count = treePostService.getTreePostCounts(treeId, principalUserDetails);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(count));
+    }
+
 }

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -88,7 +88,7 @@ public class UserController {
         List<UserTreeListResponse> treeListDTO = userService.getUserTreeList(principalUserDetails, page, size);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(treeListDTO));
     }
-    
+
     @Operation(summary = "유저의 히스토리 인증글 목록 조회", description = "유저의 히스토리 인증글 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "인증글 목록 조회 성공",
             content = @Content(mediaType = "application/json",

--- a/src/main/java/com/example/feelsun/controller/UserController.java
+++ b/src/main/java/com/example/feelsun/controller/UserController.java
@@ -88,20 +88,7 @@ public class UserController {
         List<UserTreeListResponse> treeListDTO = userService.getUserTreeList(principalUserDetails, page, size);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(treeListDTO));
     }
-
-    @Operation(summary = "둘러보기 페이지에서 나무를 클릭했을 때 나오는 인증글 목록 조회", description = "둘러보기 페이지에서 나무를 클릭했을 때 나오는 인증글 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "인증글 목록 조회 성공",
-            content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = UserTreeDetailResponse.class)))
-    @GetMapping("/trees/{treeId}")
-    public ResponseEntity<?> getUserTree(@AuthenticationPrincipal PrincipalUserDetails principalUserDetails,
-                                         @PathVariable("treeId") Integer treeId,
-                                         @RequestParam(value = "page", defaultValue = "0") int page,
-                                         @RequestParam(value = "size", defaultValue = "5") int size) {
-        List<UserTreeDetailResponse> treeDTO = userService.getUserTreeDetail(principalUserDetails, treeId, page, size);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(treeDTO));
-    }
-
+    
     @Operation(summary = "유저의 히스토리 인증글 목록 조회", description = "유저의 히스토리 인증글 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "인증글 목록 조회 성공",
             content = @Content(mediaType = "application/json",

--- a/src/main/java/com/example/feelsun/domain/TreeImage.java
+++ b/src/main/java/com/example/feelsun/domain/TreeImage.java
@@ -1,0 +1,29 @@
+package com.example.feelsun.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tree_images")
+public class TreeImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private int level;
+
+    @Column(nullable = false)
+    private String treeImageUrl;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/feelsun/repository/TreePostJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/TreePostJpaRepository.java
@@ -9,4 +9,6 @@ public interface TreePostJpaRepository extends JpaRepository<TreePost, Integer> 
     Page<TreePost> findAllByTreeId(Integer treeId, Pageable pageable);
 
     Page<TreePost> findAllByUserId(Integer userId, Pageable pageable);
+
+    int countByTreeId(Integer treeId);
 }

--- a/src/main/java/com/example/feelsun/request/TreePostRequest.java
+++ b/src/main/java/com/example/feelsun/request/TreePostRequest.java
@@ -1,14 +1,18 @@
 package com.example.feelsun.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 public class TreePostRequest {
     @Getter
     @Setter
     public static class TreePostCreateRequest {
+        // TABLE 설계 시 VARCHAR(300) 이상으로 설계할 것
         @NotNull(message = "습관 일지 내용은 필수 입력 값입니다.")
+        @Size(max = 150, message = "습관 일지 내용은 150자 이하로 입력해주세요.")
         private String content;
 
         @NotNull(message = "습관 일지 이미지는 필수 입력 값입니다.")

--- a/src/main/java/com/example/feelsun/response/UserResponse.java
+++ b/src/main/java/com/example/feelsun/response/UserResponse.java
@@ -72,13 +72,13 @@ public class UserResponse {
     public static class UserTreeListResponse {
         private Integer userId;
         private Integer treeId;
-        private String habitName;
+        private String nickname;
         private String treeImageUrl;
 
-        public UserTreeListResponse(Integer userId, Integer treeId, String habitName, String treeImageUrl) {
+        public UserTreeListResponse(Integer userId, Integer treeId, String nickname, String treeImageUrl) {
             this.userId = userId;
             this.treeId = treeId;
-            this.habitName = habitName;
+            this.nickname = nickname;
             this.treeImageUrl = treeImageUrl;
         }
 

--- a/src/main/java/com/example/feelsun/service/TreePostService.java
+++ b/src/main/java/com/example/feelsun/service/TreePostService.java
@@ -1,6 +1,8 @@
 package com.example.feelsun.service;
 
 import com.example.feelsun.config.auth.PrincipalUserDetails;
+import com.example.feelsun.config.errors.exception.Exception401;
+import com.example.feelsun.config.errors.exception.Exception403;
 import com.example.feelsun.config.errors.exception.Exception404;
 import com.example.feelsun.config.s3.S3UploadService;
 import com.example.feelsun.domain.Tree;
@@ -44,6 +46,11 @@ public class TreePostService {
         // 나무 데이터 가져오기
         Tree tree = treeJpaRepository.findById(treeId)
                 .orElseThrow(() -> new Exception404("나무를 찾을 수 없습니다."));
+
+        // 나무 데이터에서 가져온 값과 현재 유저 아이디 값이 다를 경우 예외처리
+        if (!tree.getUser().getId().equals(user.getId())) {
+            throw new Exception401("인증되지 않은 사용자입니다.");
+        }
 
         // 게시물 생성
         TreePost treePost = TreePost.builder()

--- a/src/main/java/com/example/feelsun/service/TreePostService.java
+++ b/src/main/java/com/example/feelsun/service/TreePostService.java
@@ -69,4 +69,20 @@ public class TreePostService {
         return userJpaRepository.findByUsername(principalUserDetails.getUsername())
                 .orElseThrow(() -> new Exception404("사용자를 찾을 수 없습니다."));
     }
+
+    public int getTreePostCounts(Integer treeId, PrincipalUserDetails principalUserDetails) {
+        // 인증
+        User user = validateUser(principalUserDetails);
+
+        // 나무 데이터 가져오기
+        Tree tree = treeJpaRepository.findById(treeId)
+                .orElseThrow(() -> new Exception404("나무를 찾을 수 없습니다."));
+
+        // 나무 데이터에서 가져온 값과 현재 유저 아이디 값이 다를 경우 예외처리
+        if (!tree.getUser().getId().equals(user.getId())) {
+            throw new Exception401("인증되지 않은 사용자입니다.");
+        }
+
+        return treePostJpaRepository.countByTreeId(treeId);
+    }
 }

--- a/src/main/java/com/example/feelsun/service/UserService.java
+++ b/src/main/java/com/example/feelsun/service/UserService.java
@@ -154,7 +154,7 @@ public class UserService {
         return trees
                 .getContent()
                 .stream()
-                .map(tree -> new UserTreeListResponse(tree.getUser().getId(), tree.getId(), tree.getName(), tree.getImageUrl()))
+                .map(tree -> new UserTreeListResponse(tree.getUser().getId(), tree.getId(), tree.getUser().getNickname(), tree.getImageUrl()))
                 .toList();
 
     }


### PR DESCRIPTION
## 작업 내용

<!--- 작업하신 내용을 간략하게 설명해주세요 -->

1. 나무 둘러보기 페이지에서 습관명이 아닌 닉네임 보여주기
2. 상세 페이지 API 삭제 ( 중복 API )
3. TreePostRequest 150자 이내 설정 ( 추후 DB 설계시 고려할 부분 )
4. 트리 이미지 도메인 작성
5. TreePost 작성할 때 인증 과정 추가

## 기타 및 참고 사항


## 이슈 번호

This closes #38 

<!--- 작업을 마친 이슈는 클로즈 해주세요 -->
