### PR TITLE
인증글 작성시 경험치 증가, 나무 업그레이드 및 인증글 개수 제한

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	// s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// mysql
+	runtimeOnly 'mysql:mysql-connector-java:8.0.32'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/feelsun/controller/TreeController.java
+++ b/src/main/java/com/example/feelsun/controller/TreeController.java
@@ -34,7 +34,7 @@ public class TreeController {
     @ApiResponse(responseCode = "200", description = "홈 화면 출력 완료",
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = TreeResponse.MainTreeList.class)))
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<?> treeList(@AuthenticationPrincipal PrincipalUserDetails principalUserDetails) {
         List<TreeResponse.MainTreeList> treeListDTO = treeService.treeList(principalUserDetails);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseBuilder.success(treeListDTO));

--- a/src/main/java/com/example/feelsun/domain/Tree.java
+++ b/src/main/java/com/example/feelsun/domain/Tree.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -38,7 +40,7 @@ public class Tree {
     private int price;
 
     @Column(nullable = false)
-    private boolean certification;
+    private boolean certification = false;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -65,4 +67,26 @@ public class Tree {
         this.certification = false;
     }
 
+    @Transactional
+    public void updateExperience(int experience) {
+        this.experience += experience;
+        this.certification = true;
+        this.continuousPeriod += experience;
+    }
+
+    @Transactional
+    public void upgradeTree(List<TreeImage> treeImages) {
+        // 경험치 기준값을 배열로 선언
+        int[] experienceThresholds = new int[]{1, 2, 10, 30, 50, 70, 100};
+
+        // 현재 경험치에 맞는 레벨 찾기
+        for (int i = 0; i < experienceThresholds.length; i++) {
+            if (this.experience == experienceThresholds[i]) {
+                // 레벨 업그레이드 및 이미지 URL 업데이트
+                this.level = i + 1; // 경험치에 따른 레벨 설정
+                this.imageUrl = treeImages.get(this.level).getTreeImageUrl();
+                break; // 적합한 레벨을 찾았으므로 반복 종료
+            }
+        }
+    }
 }

--- a/src/main/java/com/example/feelsun/domain/Tree.java
+++ b/src/main/java/com/example/feelsun/domain/Tree.java
@@ -83,7 +83,7 @@ public class Tree {
         for (int i = 0; i < experienceThresholds.length; i++) {
             if (this.experience == experienceThresholds[i]) {
                 // 레벨 업그레이드 및 이미지 URL 업데이트
-                this.level = i + 1; // 경험치에 따른 레벨 설정
+                this.level = i; // 경험치에 따른 레벨 설정
                 this.imageUrl = treeImages.get(this.level).getTreeImageUrl();
                 break; // 적합한 레벨을 찾았으므로 반복 종료
             }

--- a/src/main/java/com/example/feelsun/domain/Tree.java
+++ b/src/main/java/com/example/feelsun/domain/Tree.java
@@ -57,9 +57,9 @@ public class Tree {
     public Tree(String name, User user) {
         this.name = name;
         this.user = user;
-        this.level = 1;
-        this.imageUrl = "https://via.placeholder.com/150";
-        this.experience = 1;
+        this.level = 0;
+        this.imageUrl = "https://team19-bucket.s3.ap-northeast-2.amazonaws.com/4cb50b61-d7fb-44c0-a087-ed905a6ffe93.png";
+        this.experience = 0;
         this.price = 0;
         this.accessLevel = TreeEnum.FREE;
         this.createdAt = LocalDateTime.now();
@@ -77,10 +77,10 @@ public class Tree {
     @Transactional
     public void upgradeTree(List<TreeImage> treeImages) {
         // 경험치 기준값을 배열로 선언
-        int[] experienceThresholds = new int[]{1, 2, 10, 30, 50, 70, 100};
+        int[] experienceThresholds = new int[]{0, 1, 2, 10, 30, 50, 70, 100};
 
         // 현재 경험치에 맞는 레벨 찾기
-        for (int i = 0; i < experienceThresholds.length; i++) {
+        for (int i = 1; i < experienceThresholds.length; i++) {
             if (this.experience == experienceThresholds[i]) {
                 // 레벨 업그레이드 및 이미지 URL 업데이트
                 this.level = i; // 경험치에 따른 레벨 설정

--- a/src/main/java/com/example/feelsun/repository/TreeImageJpaRepository.java
+++ b/src/main/java/com/example/feelsun/repository/TreeImageJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.feelsun.repository;
+
+import com.example.feelsun.domain.TreeImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TreeImageJpaRepository extends JpaRepository<TreeImage, Integer> {
+}

--- a/src/main/java/com/example/feelsun/request/TreePostRequest.java
+++ b/src/main/java/com/example/feelsun/request/TreePostRequest.java
@@ -1,6 +1,7 @@
 package com.example.feelsun.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,6 +17,7 @@ public class TreePostRequest {
         private String content;
 
         @NotNull(message = "습관 일지 이미지는 필수 입력 값입니다.")
+        @Pattern(regexp = "^(.+)\\.(jpg|jpeg|png|gif)$", message = "지원되지 않는 이미지 확장자명입니다.")
         private String imageUrl;
     }
 }

--- a/src/main/java/com/example/feelsun/response/TreeResponse.java
+++ b/src/main/java/com/example/feelsun/response/TreeResponse.java
@@ -16,7 +16,6 @@ public class TreeResponse {
         private Integer experience;
         private String habitName;
         private String treeImageUrl;
-        private String imageUrl;
         private Integer continuousPeriod;
         private boolean certification;
     }

--- a/src/main/java/com/example/feelsun/service/TreePostService.java
+++ b/src/main/java/com/example/feelsun/service/TreePostService.java
@@ -62,6 +62,17 @@ public class TreePostService {
             throw new Exception401("인증되지 않은 사용자입니다.");
         }
 
+        // 오늘 날짜의 시작 시간과 종료 시간을 계산
+        LocalDateTime startOfToday = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+        LocalDateTime startOfNextDay = startOfToday.plusDays(1);
+
+        // 수정된 메서드를 호출
+        int todayCount = treePostJpaRepository.countByTreeIdAndCreatedAt(treeId, startOfToday, startOfNextDay);
+
+        if (todayCount >= 3) {
+            throw new Exception401("하루에 인증글은 3개까지만 작성할 수 있습니다.");
+        }
+
         // 게시물 생성
         TreePost treePost = TreePost.builder()
                 .user(user)

--- a/src/main/java/com/example/feelsun/service/TreeService.java
+++ b/src/main/java/com/example/feelsun/service/TreeService.java
@@ -134,7 +134,6 @@ public class TreeService {
         response.setExperience(tree.getExperience());
         response.setHabitName(tree.getName());
         response.setTreeImageUrl(tree.getImageUrl());
-        response.setImageUrl(tree.getImageUrl());
         response.setContinuousPeriod(tree.getContinuousPeriod());
         response.setCertification(tree.isCertification());
 

--- a/src/main/java/com/example/feelsun/service/TreeService.java
+++ b/src/main/java/com/example/feelsun/service/TreeService.java
@@ -136,6 +136,7 @@ public class TreeService {
         response.setTreeImageUrl(tree.getImageUrl());
         response.setImageUrl(tree.getImageUrl());
         response.setContinuousPeriod(tree.getContinuousPeriod());
+        response.setCertification(tree.isCertification());
 
         return response;
     }


### PR DESCRIPTION
## 작업 내용

<!--- 작업하신 내용을 간략하게 설명해주세요 -->

1. GET 요청시 오늘 작성한 인증글 수 전달 및 POST 요청으로 인증글을 작성할 때도 백엔드에서도 예외처리
2. 인증글 작성시 인증여부 true 변경, 경험치 + 1
3. 인증여부가 true 일 경우, 인증글을 추가로 올리더라도 경험치가 오르지 않음
4. 경험치가 오를 때 레벨업 여부 판단 및 이미지 업데이트 여부 판단 로직 추가

## 기타 및 참고 사항


## 이슈 번호

This closes #40 

<!--- 작업을 마친 이슈는 클로즈 해주세요 -->
